### PR TITLE
Update documentation for generating buildkite API keys

### DIFF
--- a/git-buildkite
+++ b/git-buildkite
@@ -94,7 +94,7 @@ function result_build_number() {
 }
 
 if [ -z "$BUILDKITE_API_KEY" ]; then
-  echo "You need to configure your Buildkite api key. It's on:"
+  echo "You need to create a new Buildkite api key with the 'Modify Builds (write_builds)' scope. You can do that here:"
   echo
   echo "    https://buildkite.com/user/api-access-tokens"
   echo


### PR DESCRIPTION
Buildkite no longer have a single API key but rather many API keys which can have different permissions. When users create an API for use with `git-buildkite` they require the `Modify Builds (write_builds)` permission. These doc changes instruct the user to add that permissions to their new key.
